### PR TITLE
feat: SVG path strings optional in initial values

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ All of the props are optional
 | `addPath`  | Append a path to the current drawing paths | `(path: PathType) => void`         |
 | `getSvg`   | Get SVG path string of the drawing         | `() => string`                     |
 
+## Helper functions
+
+* If you need to create an SVG path, `createSVGPath()` is available to create the string representation of an SVG path.
+
 ## Contributing
 
 See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.

--- a/src/Draw.tsx
+++ b/src/Draw.tsx
@@ -249,6 +249,39 @@ const getVisibility = (hideBottom: boolean | HideBottom): Visibility => {
   }
 };
 
+/**
+ * Generate SVG path string. Helper method for createSVGPath
+ *
+ * @param paths SVG path data
+ * @param simplifyOptions Simplification options for the SVG drawing simplification
+ * @returns SVG path strings
+ */
+const generateSVGPath = (
+  path: PathDataType,
+  simplifyOptions: SimplifyOptions
+) =>
+  createSVGPath(
+    path,
+    simplifyOptions.simplifyPaths ? simplifyOptions.amount! : 0,
+    simplifyOptions.roundPoints!
+  );
+
+/**
+ * Generate multiple SVG path strings. If the path string is already defined, do not create a new one.
+ *
+ * @param paths SVG data paths
+ * @param simplifyOptions Simplification options for the SVG drawing simplification
+ * @returns An array of SVG path strings
+ */
+const generateSVGPaths = (
+  paths: PathType[],
+  simplifyOptions: SimplifyOptions
+) =>
+  paths.map((i) => ({
+    ...i,
+    path: i.path ? i.path : generateSVGPath(i.data, simplifyOptions),
+  }));
+
 const Draw = forwardRef<DrawRef, DrawProps>(
   (
     {
@@ -267,21 +300,21 @@ const Draw = forwardRef<DrawRef, DrawProps>(
     } = {},
     ref
   ) => {
-    initialValues = {
-      color: colors[0][0][0],
-      thickness: DEFAULT_THICKNESS,
-      opacity: DEFAULT_OPACITY,
-      paths: [],
-      tool: DEFAULT_TOOL,
-      ...initialValues,
-    };
-
     simplifyOptions = {
       simplifyPaths: true,
       simplifyCurrentPath: false,
       amount: 15,
       roundPoints: true,
       ...simplifyOptions,
+    };
+
+    initialValues = {
+      color: colors[0][0][0],
+      thickness: DEFAULT_THICKNESS,
+      opacity: DEFAULT_OPACITY,
+      tool: DEFAULT_TOOL,
+      ...initialValues,
+      paths: generateSVGPaths(initialValues.paths || [], simplifyOptions),
     };
 
     const viewVisibility = getVisibility(hideBottom);
@@ -422,11 +455,7 @@ const Draw = forwardRef<DrawRef, DrawProps>(
             ...prev,
             {
               color,
-              path: createSVGPath(
-                path,
-                simplifyOptions.simplifyPaths ? simplifyOptions.amount! : 0,
-                simplifyOptions.roundPoints!
-              ),
+              path: generateSVGPath(path, simplifyOptions),
               data: path,
               thickness,
               opacity,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,3 +6,4 @@ export {
   SimplifyOptions,
 } from './Draw';
 export * from './types';
+export { createSVGPath } from './utils';

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,9 +7,10 @@ export interface PathType {
   color: string;
 
   /**
-   * SVG path
+   * SVG path. It does not need to be defined while passing a PathType to Draw as initialValues.
+   * It will always be defined if you get the path data from the component.
    */
-  path: string;
+  path?: string;
 
   /**
    * Raw points data used to create the SVG path


### PR DESCRIPTION
### Changes
* The SVG string path is not required anymore while giving initial values to the component. It will generate the path one time initially, if there are not string paths defined in the data
* With this change, we shouldn't need to re-export the `createSVGPath` from the package
* I haven't been able to test it, but will later today - simply wanted to have a change up. @cerven feel free to test this branch if you want to (doing `yarn add https://github.com/BenJeau/react-native-draw.git#feat-optional-initial-paths` or making the version in the package.json be `BenJeau/react-native-draw#feat-optional-initial-paths` should work)

### Related issues
closes #34 