### PR TITLE
fix: replace .onEnd -> .onTouchesUp in Canvas.tsx

### DIFF
--- a/packages/react-native-draw/src/Canvas.tsx
+++ b/packages/react-native-draw/src/Canvas.tsx
@@ -379,7 +379,7 @@ const Canvas = forwardRef<CanvasRef, CanvasProps>(
           addPointToPath(x, y);
         }
       })
-      .onEnd(() => {
+      .onTouchesUp(() => {
         if (tool === DrawingTool.Brush) {
           setPaths((prev) => {
             const newSVGPath = generateSVGPath(path, simplifyOptions);


### PR DESCRIPTION
## Changes

### Motivation:

- onEnd not work in ios, when tap in canvas
- I found reason that onChange not work in ios, when tap in canvas

### Modifications:

- replace .onEnd -> .onTouchesUp in Canvas.tsx

## Related Issues

#66

## Screenshots (optional)

![image](https://user-images.githubusercontent.com/59603575/234559498-b252ebd9-6873-4adc-8062-44a7c61ddf5d.png)

