### PR TITLE
fix: app crash when opacity slider is moved to 0

### DIFF
--- a/packages/react-native-draw-extras/src/brushProperties/BrushProperties.tsx
+++ b/packages/react-native-draw-extras/src/brushProperties/BrushProperties.tsx
@@ -126,7 +126,7 @@ const BrushProperties = forwardRef<BrushPropertiesRef, BrushPropertiesProps>(
           colors={colors}
           onColorChange={onColorChange}
         />
-        {thickness && onThicknessChange && opacity && onOpacityChange && (
+        {!!thickness && !!onThicknessChange && !!onOpacityChange && (
           <View style={styles.sliderContainer}>
             {thickness && onThicknessChange && (
               <Slider
@@ -139,7 +139,7 @@ const BrushProperties = forwardRef<BrushPropertiesRef, BrushPropertiesProps>(
                 minimumTrackTintColor={sliderColor}
               />
             )}
-            {opacity && onOpacityChange && (
+            {onOpacityChange && (
               <Slider
                 minimumValue={0}
                 maximumValue={1}


### PR DESCRIPTION
## Changes

Motivation:
- When the opacity slider is moved to 0, the app crashes
- When the opacity slider is moved to 0, slider not visible

Modifications:
- add !! prefix check value
- erase opacity value in logic conditional render (detail in the commit)

## Screenshots (optional)
- origin
![image](https://user-images.githubusercontent.com/59603575/236608867-df1932db-560c-4efc-9abe-2e56cce12460.png)

- add !! prefix in logic conditional render
![image](https://user-images.githubusercontent.com/59603575/236608928-2336af7f-7022-4e9d-b45b-37133d033d20.png)


